### PR TITLE
[feat/#3]: Bottom Navigation Bar Customizing

### DIFF
--- a/lib/Widgets/fluid_navbar.dart
+++ b/lib/Widgets/fluid_navbar.dart
@@ -19,6 +19,7 @@ class FluidNavBarState extends State<FluidNavBar> {
   final List<NavItem> _navItems = [
     NavItem(Icons.image, "Image"),
     NavItem(Icons.calendar_today, "Calendar"),
+    NavItem(Icons.chat, ""),
     NavItem(Icons.group, "Group"),
     NavItem(Icons.settings, "Settings"),
   ];
@@ -33,11 +34,16 @@ class FluidNavBarState extends State<FluidNavBar> {
   @override
   Widget build(BuildContext context) {
     return BottomAppBar(
-      shape: const CircularNotchedRectangle(),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: _navItems.map((item) {
           var index = _navItems.indexOf(item);
+          if (index == 2) {
+            return const IconButton(
+              onPressed: null,
+              icon: Icon(null)
+            );
+          }
           return IconButton(
             onPressed: () => _onNavItemTapped(index),
             icon: Icon(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ class MyHomePage extends StatelessWidget {
         children: const [
           Gallery(),
           Text("world2"),
+          Text("easter eggs"),
           Text("hello3"),
           Text("world4"),
         ],


### PR DESCRIPTION
## 개요
바텀 내비게이션 디자인 커스텀

## 작업사항
- 가운데 FAB을 위한 공간 확보

## 변경된 부분
- 색인 상 2번 페이지에 대해 Text 이스터 에그 추가

## 실행 화면
<img width="502" alt="image" src="https://github.com/22nd-Hoondong/Re-Frame/assets/62137001/27cf5c50-e72d-4cf0-833c-0439968adbcc">

