### PR TITLE
[BUG] 사용자 이름이 나오지 않는 문제 수정

### DIFF
--- a/lib/Widgets/postmodal.dart
+++ b/lib/Widgets/postmodal.dart
@@ -8,6 +8,7 @@ import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 class PostModal extends StatelessWidget {
   final Post _post;
   final PageController pageController = PageController();
+  final db = FirebaseFirestore.instance;
 
   PostModal({super.key, required Post post}) : _post = post;
 
@@ -92,9 +93,12 @@ class PostModal extends StatelessWidget {
                             margin: const EdgeInsets.only(bottom: 10),
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                              children: _post.people.map((docRef) {
+                              children: _post.people.map((userId) {
                                 return FutureBuilder(
-                                    future: docRef.get(),
+                                    future: db
+                                        .collection("users")
+                                        .doc(userId)
+                                        .get(),
                                     builder: (BuildContext context,
                                         AsyncSnapshot<DocumentSnapshot>
                                             snapshot) {


### PR DESCRIPTION
## 개요
firebase 스키마 변경으로 인해 사용자 이름이 나오지 않는 문제를 수정합니다.

## 작업사항
기존에는 ref로 받던 사용자 정보를 userId기반 collection을 받아오는 것으로 수정했습니다.

## 변경된 부분
- docRef -> db.collection코드로 변경

## 실행 화면
<img width="360" alt="스크린샷 2023-11-30 오전 9 49 38" src="https://github.com/22nd-Hoondong/Re-Frame/assets/52999093/a33faecc-df0e-438c-b266-85ea25c3253e">