### PR TITLE
[Feat] 갤러리 페이지에서 꾹 누르기 기능 추가

### DIFF
--- a/lib/Widgets/image_container.dart
+++ b/lib/Widgets/image_container.dart
@@ -45,6 +45,7 @@ class _ImageContainerState extends State<ImageContainer> {
                       context: context,
                       barrierDismissible: false, //바깥 영역 터치시 닫을지 여부 결정
                       builder: (context) => AlertDialog(
+                        actionsAlignment: MainAxisAlignment.spaceBetween,
                         backgroundColor: Colors.white,
                         title: const Text(
                           "사진을 삭제하시겠습니까?",

--- a/lib/Widgets/image_container.dart
+++ b/lib/Widgets/image_container.dart
@@ -45,11 +45,12 @@ class _ImageContainerState extends State<ImageContainer> {
                       context: context,
                       barrierDismissible: false, //바깥 영역 터치시 닫을지 여부 결정
                       builder: (context) => AlertDialog(
-                        title: Text(
+                        title: const Text(
                           "사진을 삭제하시겠습니까?",
                           style: TextStyle(
-                              fontWeight: FontWeight.w600,
-                              color: Theme.of(context).primaryColor),
+                            fontWeight: FontWeight.w600,
+                            color: Colors.black,
+                          ),
                         ),
                         actions: [
                           SizedBox(
@@ -63,6 +64,9 @@ class _ImageContainerState extends State<ImageContainer> {
                               },
                               child: const Text(
                                 "네",
+                                style: TextStyle(
+                                  color: Colors.black,
+                                ),
                               ),
                             ),
                           ),
@@ -74,6 +78,9 @@ class _ImageContainerState extends State<ImageContainer> {
                               },
                               child: const Text(
                                 "아니오",
+                                style: TextStyle(
+                                  color: Colors.black,
+                                ),
                               ),
                             ),
                           ),

--- a/lib/Widgets/image_container.dart
+++ b/lib/Widgets/image_container.dart
@@ -45,6 +45,7 @@ class _ImageContainerState extends State<ImageContainer> {
                       context: context,
                       barrierDismissible: false, //바깥 영역 터치시 닫을지 여부 결정
                       builder: (context) => AlertDialog(
+                        backgroundColor: Colors.white,
                         title: const Text(
                           "사진을 삭제하시겠습니까?",
                           style: TextStyle(

--- a/lib/Widgets/image_container.dart
+++ b/lib/Widgets/image_container.dart
@@ -38,10 +38,54 @@ class _ImageContainerState extends State<ImageContainer> {
                   color: const Color(0xFFD9D9D9),
                   child: const Icon(Icons.add_a_photo_outlined),
                 )
-              : Image.memory(
-                  imageData!,
-                  height: widget.height,
-                  width: widget.width,
+              : GestureDetector(
+                  onTap: () {},
+                  onLongPress: () {
+                    showDialog(
+                      context: context,
+                      barrierDismissible: false, //바깥 영역 터치시 닫을지 여부 결정
+                      builder: (context) => AlertDialog(
+                        title: Text(
+                          "사진을 삭제하시겠습니까?",
+                          style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              color: Theme.of(context).primaryColor),
+                        ),
+                        actions: [
+                          SizedBox(
+                            width: 100,
+                            child: TextButton(
+                              onPressed: () {
+                                setState(() {
+                                  imageData = null;
+                                });
+                                Navigator.of(context).pop();
+                              },
+                              child: const Text(
+                                "네",
+                              ),
+                            ),
+                          ),
+                          SizedBox(
+                            width: 100,
+                            child: TextButton(
+                              onPressed: () {
+                                Navigator.of(context).pop();
+                              },
+                              child: const Text(
+                                "아니오",
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                  child: Image.memory(
+                    imageData!,
+                    height: widget.height,
+                    width: widget.width,
+                  ),
                 ),
           Positioned(
             bottom: widget.height,


### PR DESCRIPTION
## 개요
Gallery Page에서 사진을 꾹 누르면 나오는 기능을 추가했습니다.

## 작업사항
- Gallery 페이지의 회색 container를 누르면 사진 선택창이 나옴
- 사진이 생기면, 해당 사진을 onTap한다고 해서 사진 선택창이 나오지 않음
- 사진을 삭제하려면 해당 사진을 onLongPress해서 나오는 모달 창을 선택해야함
- 모달창에서 아니오를 누르면 현상 유지
- 모달 창에서 예를 누르면 사진이 사라짐
- 사진을 변경하고 싶다면 위의 과정을 반복하면 됨

## 변경된 부분
- 이미 사진이 있을 때, 다시 사진 선택창에 들어가야 사진을 제거해야하는 문제점 해결
- 이미 사진이 있을 때, 다시 모달 창이 나오는 문제점 해결
- 회색 화면에서 꾹 누르는 gesture 방지

## 실행 화면
![image](https://github.com/22nd-Hoondong/Re-Frame/assets/52999093/c3fb442a-c913-44ae-b1f5-69d24d8c10b5)
