### PR TITLE
[Feat]: Post Modal에 SingleChildScrollView 추가

### DIFF
--- a/lib/Widgets/postmodal.dart
+++ b/lib/Widgets/postmodal.dart
@@ -91,30 +91,37 @@ class PostModal extends StatelessWidget {
                                 color: Colors.white,
                                 border: Border.all(style: BorderStyle.solid)),
                             margin: const EdgeInsets.only(bottom: 10),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                              children: _post.people.map((userId) {
-                                return FutureBuilder(
-                                    future: db
-                                        .collection("users")
-                                        .doc(userId)
-                                        .get(),
-                                    builder: (BuildContext context,
-                                        AsyncSnapshot<DocumentSnapshot>
-                                            snapshot) {
-                                      if (snapshot.hasData) {
-                                        Map<String, dynamic> doc =
-                                            snapshot.data!.data()
-                                                as Map<String, dynamic>;
-                                        return Text(
-                                          doc["name"],
-                                          style: const TextStyle(
-                                              color: Colors.grey),
-                                        );
-                                      }
-                                      return const CircularProgressIndicator();
-                                    });
-                              }).toList(),
+                            child: SingleChildScrollView(
+                              scrollDirection: Axis.horizontal,
+                              child: SizedBox(
+                                width: 420,
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceEvenly,
+                                  children: _post.people.map((userId) {
+                                    return FutureBuilder(
+                                        future: db
+                                            .collection("users")
+                                            .doc(userId)
+                                            .get(),
+                                        builder: (BuildContext context,
+                                            AsyncSnapshot<DocumentSnapshot>
+                                                snapshot) {
+                                          if (snapshot.hasData) {
+                                            Map<String, dynamic> doc =
+                                                snapshot.data!.data()
+                                                    as Map<String, dynamic>;
+                                            return Text(
+                                              doc["name"],
+                                              style: const TextStyle(
+                                                  color: Colors.grey),
+                                            );
+                                          }
+                                          return const CircularProgressIndicator();
+                                        });
+                                  }).toList(),
+                                ),
+                              ),
                             ),
                           ),
                           Text(_post.content),


### PR DESCRIPTION
## 개요
Post Modal에 SingleChildScrollView 추가

## 작업사항
- Post Modal에 SingleChildScrollView 추가

## 변경된 부분
- Row 위젯 대신에 SingleChildScrollView 추가

## 실행 화면
![image](https://github.com/22nd-Hoondong/Re-Frame/assets/52999093/23d6b2a7-ec42-48ea-aecd-3209f8d262cf)

