### PR TITLE
[BUG] 켈린더에서 나와 상관없는 페이지가 나옴.

### DIFF
--- a/lib/Pages/calendar.dart
+++ b/lib/Pages/calendar.dart
@@ -36,30 +36,31 @@ class _CalendarState extends State<Calendar>
   ); // cascade notation.
   final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
 
-  void getFirebasePosts() async {
-    QuerySnapshot<Map<String, dynamic>> querySnapshot =
-        await db.collection("posts").get();
-    for (var element in querySnapshot.docs) {
-      Map<String, dynamic> postData = element.data();
-      List<dynamic> peopleList = postData['people'];
-      if (peopleList.contains(_firebaseAuth.currentUser?.uid)) {
-        Timestamp firebaseDate = postData["date"];
-        DateTime postDate = DateTime.parse(firebaseDate.toDate().toString());
-        Post newPostObj = Post(
-            title: postData["title"],
-            content: postData["content"],
-            date: postDate,
-            people: postData["people"],
-            photos: postData["photos"]);
-        setState(() {
-          if (kEvents.containsKey(postDate)) {
-            kEvents[postDate]!.add(newPostObj);
-          } else {
-            kEvents[postDate] = [newPostObj];
-          }
-        });
+  void getFirebasePosts() {
+    CollectionReference postRef = db.collection("posts");
+    postRef.snapshots().listen((event) {
+      for (var element in event.docs) {
+        Map<String, dynamic> postData = element.data() as Map<String, dynamic>;
+        List<dynamic> peopleList = postData['people'];
+        if (peopleList.contains(_firebaseAuth.currentUser?.uid)) {
+          Timestamp firebaseDate = postData["date"];
+          DateTime postDate = DateTime.parse(firebaseDate.toDate().toString());
+          Post newPostObj = Post(
+              title: postData["title"],
+              content: postData["content"],
+              date: postDate,
+              people: postData["people"],
+              photos: postData["photos"]);
+          setState(() {
+            if (kEvents.containsKey(postDate)) {
+              kEvents[postDate]!.add(newPostObj);
+            } else {
+              kEvents[postDate] = [newPostObj];
+            }
+          });
+        }
       }
-    }
+    });
   }
 
   @override

--- a/lib/Pages/calendar.dart
+++ b/lib/Pages/calendar.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:re_frame/Widgets/postmodal.dart';
 import 'package:re_frame/calendar_util.dart';
@@ -33,27 +34,31 @@ class _CalendarState extends State<Calendar>
     equals: isSameDay,
     hashCode: getHashCode,
   ); // cascade notation.
+  final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
 
   void getFirebasePosts() async {
     QuerySnapshot<Map<String, dynamic>> querySnapshot =
         await db.collection("posts").get();
     for (var element in querySnapshot.docs) {
       Map<String, dynamic> postData = element.data();
-      Timestamp firebaseDate = postData["date"];
-      DateTime postDate = DateTime.parse(firebaseDate.toDate().toString());
-      Post newPostObj = Post(
-          title: postData["title"],
-          content: postData["content"],
-          date: postDate,
-          people: postData["people"],
-          photos: postData["photos"]);
-      setState(() {
-        if (kEvents.containsKey(postDate)) {
-          kEvents[postDate]!.add(newPostObj);
-        } else {
-          kEvents[postDate] = [newPostObj];
-        }
-      });
+      List<dynamic> peopleList = postData['people'];
+      if (peopleList.contains(_firebaseAuth.currentUser?.uid)) {
+        Timestamp firebaseDate = postData["date"];
+        DateTime postDate = DateTime.parse(firebaseDate.toDate().toString());
+        Post newPostObj = Post(
+            title: postData["title"],
+            content: postData["content"],
+            date: postDate,
+            people: postData["people"],
+            photos: postData["photos"]);
+        setState(() {
+          if (kEvents.containsKey(postDate)) {
+            kEvents[postDate]!.add(newPostObj);
+          } else {
+            kEvents[postDate] = [newPostObj];
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## 개요
캘린더에서 나와 상관없는 페이지가 나오는 문제를 해겷했습니다.

## 작업사항
- 캘린더에서 페이지를 불러올 때, 현재 로그인 되어있는 사용자의 id가 있는 경우만 post데이터를 불러오게 변경
- 추가적으로 게시글에 업로드 되면 firebase collection이 바뀌는데, 그 변화를 감지해서 다시 사용자 post를 받아오게 함.

## 변경된 부분
- 사용자 데이터를 받아올 때 currentuser.uid를 확인하는 부분 추가
- 기존에는 calendar page가 위젯트리에 마운트 되면 한번만 수행한 것을 ref.snapshots.listen함수를 이용해서 ref되어있는 데이터가 변경되면 해당 함수를 다시 호출하는 콜백함수 추가.

## 실행 화면
![image](https://github.com/22nd-Hoondong/Re-Frame/assets/52999093/de0fefd9-ad97-4872-b852-7bf2a1ed4af9)


## 특이사항
- 버그 2개를 한번에 처리했음 ㅠ
