### PR TITLE
[BUG] 자신과 상관 없는 이미지 불러오는 문제

### DIFF
--- a/lib/Widgets/photo_modal.dart
+++ b/lib/Widgets/photo_modal.dart
@@ -15,38 +15,41 @@ class PhotoModal extends StatelessWidget {
         appBar: AppBar(
           backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         ),
-        body: FutureBuilder(
-          future: db.collection("photos").get(),
+        body: StreamBuilder(
+          stream: db.collection("photos").snapshots(),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
+              // user.id
               return GridView.count(
                 crossAxisCount: 3,
-                children: snapshot.data!.docs
-                    .map((element) => FutureBuilder(
-                          future: storageRef
-                              .child("${element.id}.png")
-                              .getData(10000 * 10000),
-                          builder: (context, snapshots) {
-                            if (snapshots.hasData) {
-                              return GestureDetector(
-                                onTap: () {
-                                  Navigator.pop(context, snapshots.data);
-                                },
-                                child: Image.memory(
-                                  snapshots.data!,
-                                  width: 150,
-                                  height: 150,
-                                ),
-                              );
-                            }
-                            return const SizedBox(
-                              height: 30,
-                              width: 30,
-                              child: Center(child: CircularProgressIndicator()),
-                            );
-                          },
-                        ))
-                    .toList(),
+                children: snapshot.data!.docs.map(
+                  (element) {
+                    return FutureBuilder(
+                      future: storageRef
+                          .child("${element.id}.png")
+                          .getData(10000 * 10000),
+                      builder: (context, snapshots) {
+                        if (snapshots.hasData) {
+                          return GestureDetector(
+                            onTap: () {
+                              Navigator.pop(context, snapshots.data);
+                            },
+                            child: Image.memory(
+                              snapshots.data!,
+                              width: 150,
+                              height: 150,
+                            ),
+                          );
+                        }
+                        return const SizedBox(
+                          height: 30,
+                          width: 30,
+                          child: Center(child: CircularProgressIndicator()),
+                        );
+                      },
+                    );
+                  },
+                ).toList(),
               );
             }
             return const Center(

--- a/lib/Widgets/photo_modal.dart
+++ b/lib/Widgets/photo_modal.dart
@@ -11,7 +11,7 @@ class PhotoModal extends StatelessWidget {
   final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
   final Reference storageRef = FirebaseStorage.instance.ref();
 
-  Future<Set<String>> getUserIdList() async {
+  Future<Set<String>> getPhotoIdList() async {
     Set<String> idSet = {};
     final userPostCollectionRef = await db
         .collection("users/${_firebaseAuth.currentUser?.uid}/posts")
@@ -33,7 +33,7 @@ class PhotoModal extends StatelessWidget {
           backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         ),
         body: FutureBuilder(
-          future: getUserIdList(),
+          future: getPhotoIdList(),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               return GridView.count(


### PR DESCRIPTION
## 개요
자신과 상관 없는 이미지를 불러오는 문제를 수정했습니다.

## 작업사항
- 현재 로그인 되어있는 사용자가 가지고 있는 post를 읽어서 해당 post에 있는 사진만을 gallery 페이지에서 불러오게 변경했습니다.

## 변경된 부분
- photos collection을 전부 읽는 부분을 변경함
- 그 자리에 getPhotoIdList함수를 넣음
- getPhotoIdLIst함수는 다음을 수행함
- 1. users collection에서 현재 사용자의 uid인 doc의 posts collection을 접근
- 2. 해당 post id를 가지고 post collection에서 해당 post id랑 일치하는 doc을 접근
- 3. 해당 doc의 photos id를 받아서 Future type으로 return

## 실행 화면
![image](https://github.com/22nd-Hoondong/Re-Frame/assets/52999093/3527bc82-22b6-4fb2-86a5-da9c819892cb)


## 특이사항
- 빠른 리뷰 부탁
