### PR TITLE
[Feat] 저장된 갤러리 화면 유지 기능

### DIFF
--- a/lib/Pages/gallery.dart
+++ b/lib/Pages/gallery.dart
@@ -31,14 +31,17 @@ class _GalleryState extends State<Gallery>
                 ImageContainer(
                   height: 200,
                   width: 100,
+                  photoId: 0,
                 ),
                 ImageContainer(
                   height: 200,
                   width: 100,
+                  photoId: 1,
                 ),
                 ImageContainer(
                   height: 200,
                   width: 100,
+                  photoId: 2,
                 ),
               ],
             ),
@@ -48,14 +51,17 @@ class _GalleryState extends State<Gallery>
                 ImageContainer(
                   height: 200,
                   width: 100,
+                  photoId: 3,
                 ),
                 ImageContainer(
                   height: 200,
                   width: 100,
+                  photoId: 4,
                 ),
                 ImageContainer(
                   height: 200,
                   width: 100,
+                  photoId: 5,
                 ),
               ],
             )

--- a/lib/Widgets/image_container.dart
+++ b/lib/Widgets/image_container.dart
@@ -31,14 +31,13 @@ class _ImageContainerState extends State<ImageContainer> {
     getImageIntoSharedPref();
   }
 
-  void getImageIntoSharedPref() async {
+  Future<Uint8List?> getImageIntoSharedPref() async {
+    Uint8List? imageReturn;
     pref = await SharedPreferences.getInstance();
-    print("---");
-    print(pref.getKeys());
-    print(widget.photoId);
-    print("---");
     String? printableString = pref.get("${widget.photoId}") as String?;
-    imageData = printableString != null ? base64.decode(printableString) : null;
+    imageReturn =
+        printableString != null ? base64.decode(printableString) : null;
+    return imageReturn;
   }
 
   @override

--- a/lib/Widgets/image_container.dart
+++ b/lib/Widgets/image_container.dart
@@ -23,116 +23,115 @@ class ImageContainer extends StatefulWidget {
 
 class _ImageContainerState extends State<ImageContainer> {
   Uint8List? imageData;
-  late final SharedPreferences pref;
 
-  @override
-  void initState() {
-    super.initState();
-    getImageIntoSharedPref();
-  }
-
-  Future<Uint8List?> getImageIntoSharedPref() async {
-    Uint8List? imageReturn;
-    pref = await SharedPreferences.getInstance();
+  Future<void> getImageIntoSharedPref() async {
+    final SharedPreferences pref = await SharedPreferences.getInstance();
     String? printableString = pref.get("${widget.photoId}") as String?;
-    imageReturn =
-        printableString != null ? base64.decode(printableString) : null;
-    return imageReturn;
+    imageData = printableString != null ? base64.decode(printableString) : null;
+    return;
   }
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () async {
-        imageData = await Navigator.push(
-            context, MaterialPageRoute(builder: (context) => PhotoModal()));
-        if (imageData != null) {
-          String printableString = base64.encode(imageData!);
-          await pref.setString("${widget.photoId}", printableString);
-          setState(() {});
-        }
-      },
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          imageData == null
-              ? Container(
-                  height: widget.height,
-                  width: widget.width,
-                  color: const Color(0xFFD9D9D9),
-                  child: const Icon(Icons.add_a_photo_outlined),
-                )
-              : GestureDetector(
-                  onTap: () {},
-                  onLongPress: () {
-                    showDialog(
-                      context: context,
-                      barrierDismissible: false, //바깥 영역 터치시 닫을지 여부 결정
-                      builder: (context) => AlertDialog(
-                        actionsAlignment: MainAxisAlignment.spaceBetween,
-                        backgroundColor: Colors.white,
-                        title: const Text(
-                          "사진을 삭제하시겠습니까?",
-                          style: TextStyle(
-                            fontWeight: FontWeight.w600,
-                            color: Colors.black,
-                          ),
+    return FutureBuilder(
+        future: getImageIntoSharedPref(),
+        builder: (context, snapshot) {
+          return GestureDetector(
+            onTap: () async {
+              imageData = await Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => PhotoModal()));
+              if (imageData != null) {
+                final SharedPreferences pref =
+                    await SharedPreferences.getInstance();
+                String printableString = base64.encode(imageData!);
+                await pref.setString("${widget.photoId}", printableString);
+                setState(() {});
+              }
+            },
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                imageData == null
+                    ? Container(
+                        height: widget.height,
+                        width: widget.width,
+                        color: const Color(0xFFD9D9D9),
+                        child: const Icon(Icons.add_a_photo_outlined),
+                      )
+                    : GestureDetector(
+                        onTap: () {},
+                        onLongPress: () {
+                          showDialog(
+                            context: context,
+                            barrierDismissible: false, //바깥 영역 터치시 닫을지 여부 결정
+                            builder: (context) => AlertDialog(
+                              actionsAlignment: MainAxisAlignment.spaceBetween,
+                              backgroundColor: Colors.white,
+                              title: const Text(
+                                "사진을 삭제하시겠습니까?",
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  color: Colors.black,
+                                ),
+                              ),
+                              actions: [
+                                SizedBox(
+                                  width: 100,
+                                  child: TextButton(
+                                    onPressed: () async {
+                                      setState(() {
+                                        imageData = null;
+                                      });
+                                      final SharedPreferences pref =
+                                          await SharedPreferences.getInstance();
+                                      await pref.remove("${widget.photoId}");
+                                      if (!mounted) return;
+                                      Navigator.of(context).pop();
+                                    },
+                                    child: const Text(
+                                      "네",
+                                      style: TextStyle(
+                                        color: Colors.black,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                                SizedBox(
+                                  width: 100,
+                                  child: TextButton(
+                                    onPressed: () {
+                                      Navigator.of(context).pop();
+                                    },
+                                    child: const Text(
+                                      "아니오",
+                                      style: TextStyle(
+                                        color: Colors.black,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                        child: Image.memory(
+                          imageData!,
+                          height: widget.height,
+                          width: widget.width,
                         ),
-                        actions: [
-                          SizedBox(
-                            width: 100,
-                            child: TextButton(
-                              onPressed: () async {
-                                setState(() {
-                                  imageData = null;
-                                });
-                                await pref.remove("${widget.photoId}");
-                                if (!mounted) return;
-                                Navigator.of(context).pop();
-                              },
-                              child: const Text(
-                                "네",
-                                style: TextStyle(
-                                  color: Colors.black,
-                                ),
-                              ),
-                            ),
-                          ),
-                          SizedBox(
-                            width: 100,
-                            child: TextButton(
-                              onPressed: () {
-                                Navigator.of(context).pop();
-                              },
-                              child: const Text(
-                                "아니오",
-                                style: TextStyle(
-                                  color: Colors.black,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
                       ),
-                    );
-                  },
-                  child: Image.memory(
-                    imageData!,
-                    height: widget.height,
-                    width: widget.width,
+                Positioned(
+                  bottom: widget.height,
+                  left: widget.width / 4,
+                  child: const Image(
+                    image: AssetImage("images/pin_transparent.png"),
+                    height: 50,
+                    width: 50,
                   ),
                 ),
-          Positioned(
-            bottom: widget.height,
-            left: widget.width / 4,
-            child: const Image(
-              image: AssetImage("images/pin_transparent.png"),
-              height: 50,
-              width: 50,
+              ],
             ),
-          ),
-        ],
-      ),
-    );
+          );
+        });
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import file_selector_macos
 import firebase_auth
 import firebase_core
 import firebase_storage
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -17,4 +18,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -520,6 +528,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   pigeon:
     dependency: transitive
     description:
@@ -528,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "11.0.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -560,6 +600,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   simple_gesture_detector:
     dependency: transitive
     description:
@@ -669,6 +765,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.4-beta"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: b0f37db61ba2f2e9b7a78a1caece0052564d1bc70668156cf3a29d676fe4e574
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   firebase_auth: ^4.12.1
   google_sign_in: ^6.1.5
   smooth_page_indicator: ^1.1.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 개요
갤러리 페이지에 사진을 등록하면 앱이 꺼져도 해당 상태가 남아있는 기능을 구현했습니다.

## 작업사항
- 해당 사진을 local Storage에 저장을 해서 상태를 관리하기 위해서 shared_preference 패키지 설치
- 처음 이미지 컨테이너가 불러왔을 때, 해당 스토리지에 키가 있으면 그 값을 가져와서 imageData에 넣음
- 해당 스토리지에 키가 없으면 imageData는 null
- 이미지를 선택할 때, 그 값을 base64로 인코딩 해서 문자열로 바꾼다음에 localStorage에 저장
- 이미지를 삭제하면 그 값을 localStorage에서 삭제

## 변경된 부분
- shared_preference 패키지 설치
- initState에서 최초에 사진을 불러옴
- 사진을 불러오는 것은 비동기이기 때문에 전체 컨테이너를 Futurebuilder로 감싸서 해당 Future가 완전히 resolve될때 까지 대기.
- 사진을 선택하면 localStorage에 base64로 인코딩해서 저장
- 사진을 선택해제하면 localStoarge에 key를 이용해서 삭제
- 사진을 불러오는것은 String을 다시 base64 decoding을 함.

## 실행 화면
![image](https://github.com/22nd-Hoondong/Re-Frame/assets/52999093/36cad872-a6c2-4576-8740-0a85388727bd)