### PR TITLE
[Bug] 사진을 선택하지 않고 나왔을 때 해당 칸이 선택되어있는 것처럼 보이던 문제

### DIFF
--- a/lib/Pages/upload.dart
+++ b/lib/Pages/upload.dart
@@ -91,7 +91,7 @@ class _UploadScreenState extends State<UploadScreen> {
                       onPressed: () {
                         getImage(ImageSource.camera, selected);
                         setState(() {
-                          selected++;
+                          if (imageList[selected] != null) selected++;
                         });
                       },
                       child: const Text('카메라')),
@@ -102,7 +102,7 @@ class _UploadScreenState extends State<UploadScreen> {
                       onPressed: () {
                         getImage(ImageSource.gallery, selected);
                         setState(() {
-                          selected++;
+                          if (imageList[selected] != null) selected++;
                         });
                       },
                       child: const Text('갤러리')),


### PR DESCRIPTION
## 작업사항
- 사진을 선택하지 않고 나왔을 때 해당 칸이 선택되어있는 것처럼 보이던 문제를 수정하였습니다.

## 실행 화면

<img width="337" alt="스크린샷 2023-12-09 오후 4 31 00" src="https://github.com/22nd-Hoondong/Re-Frame/assets/49887550/6f90f6ec-cd05-48fa-83bc-53c6ab648382">
