### PR TITLE
[BUG] 로그아웃 후 새 계정 로그인

### DIFF
--- a/lib/Pages/setting.dart
+++ b/lib/Pages/setting.dart
@@ -93,7 +93,7 @@ class _SettingState extends State<Setting> with MyHomePageStateMixin {
   Future<void> signOutGoogle() async {
     await _firebaseAuth.signOut();
     await GoogleSignIn().signOut();
-    Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (context) => LoginPage()),(route) => false);
+    Navigator.of(context).popUntil((Route<dynamic> route) => false);
   }
 
   Future<void> deleteAccount() async {


### PR DESCRIPTION
## 개요
[BUG] 로그아웃 후 새 계정 로그인 #62 

## 작업사항
- 로그아웃 후 새로 로그인하면 홈화면으로 이동이 안되는 버그 수정

## 변경된 부분
- 로그아웃 시 페이지 전부 pop()
